### PR TITLE
Fix hanging b/c content length is not reset

### DIFF
--- a/SwiftSCGI/SCGIMessage.swift
+++ b/SwiftSCGI/SCGIMessage.swift
@@ -13,7 +13,7 @@ func SCGIHeadersLength(message: NSData) -> Int? {
 		let colonRange = s.rangeOfString(":")
 		assert(colonRange.location != NSNotFound, "SCGI Content-Length not found")
 		let lengthString = s.substringToIndex(colonRange.location)
-		return lengthString.toInt()
+		return Int(lengthString)
 	}
 
 	return nil;
@@ -48,9 +48,9 @@ public struct SCGIMessage {
 	}
 
 	private func parseHeadersLength(bytes: [UInt8]) -> (headersLength: Int?, rest: [UInt8]) {
-		if let colon = find(bytes, UInt8(":")) {
+		if let colon = bytes.indexOf(UInt8(":".unicodeScalars.first!.value)) {
 			if let lengthStr = String(bytes: bytes[0..<colon], encoding: NSASCIIStringEncoding) {
-				if let length = lengthStr.toInt() {
+				if let length = Int(lengthStr) {
 					let rest = Array(bytes[colon + 1..<bytes.count])
 					return (length, rest)
 				}
@@ -62,7 +62,7 @@ public struct SCGIMessage {
 	private func parseHeaders(bytes: [UInt8], headersLength: Int) -> (headers: SCGIHeaders, rest: [UInt8]) {
 		// Each Header is a pair of strings terminated by zero. (i.e. name 00 value 00)
 		//
-		let splits = split(bytes, { $0 == 00 }, allowEmptySlices: true)
+		let splits = bytes.split(allowEmptySlices: true, isSeparator: { $0 == 00 })
 
 		// Convert splits to strings
 		//
@@ -88,7 +88,7 @@ public struct SCGIMessage {
 	}
 
 	private func bytesToString(bytes: [UInt8]) -> String {
-		return reduce(bytes, "") { (str, byte) in
+		return bytes.reduce("") { (str, byte) in
 			str + String(Character(UnicodeScalar(byte)))
 		}
 	}

--- a/SwiftSCGI/SCGIMessageHandler.swift
+++ b/SwiftSCGI/SCGIMessageHandler.swift
@@ -61,7 +61,7 @@ public class SCGIMessageHandler : NSObject {
 	}
 
 	func headersString(message: SCGIMessage) -> String {
-		return reduce(sorted(message.headers.keys), "") { (s, key) in
+		return message.headers.keys.sort().reduce("") { (s, key) in
 			s + "\(key) = \(message.headers[key]!)<br/>"
 		}
 	}

--- a/SwiftSCGI/SCGIServer.swift
+++ b/SwiftSCGI/SCGIServer.swift
@@ -117,7 +117,7 @@ public class SCGIServer : NSObject {
 	//
 	func receiveIncomingConnectionNotification(notification: NSNotification) {
 		let userInfo = notification.userInfo!
-		let incomingFileHandle = userInfo[NSFileHandleNotificationFileHandleItem] as NSFileHandle?
+		let incomingFileHandle = userInfo[NSFileHandleNotificationFileHandleItem] as! NSFileHandle?
 
 		if incomingFileHandle != nil {
 			incomingRequests[incomingFileHandle!] = NSMutableData()
@@ -139,7 +139,7 @@ public class SCGIServer : NSObject {
 	// a SCGIResponseHandler will be spawned to generate a response.
 	//
 	func receiveIncomingDataNotification(notification: NSNotification) {
-		let incomingFileHandle = notification.object as NSFileHandle!
+		let incomingFileHandle = notification.object as! NSFileHandle!
 		let incomingData = incomingFileHandle?.availableData
 
 		if incomingData?.length == 0 {
@@ -186,7 +186,7 @@ public class SCGIServer : NSObject {
 	//
 	func closeHandler(handler: SCGIMessageHandler) {
 		handler.endResponse()
-		if let index = find(responseHandlers, handler) {
+		if let index = responseHandlers.indexOf(handler) {
 			responseHandlers.removeAtIndex(index)
 		}
 	}
@@ -245,7 +245,7 @@ public class SCGIServer : NSObject {
 	//    errorName - the description used for the error
 	//
 	private func errorWithName(errorName: NSString) {
-		let userInfo = [NSLocalizedDescriptionKey: NSLocalizedString(errorName, comment: "")]
+		let userInfo = [NSLocalizedDescriptionKey: NSLocalizedString(errorName as String, comment: "")]
 		lastError = NSError(domain: "SCGIServerError", code: 0, userInfo: userInfo)
 	}
 

--- a/SwiftSCGI/SCGIServer.swift
+++ b/SwiftSCGI/SCGIServer.swift
@@ -168,6 +168,7 @@ public class SCGIServer : NSObject {
 
 		if (requestData?.length >= SCGIHeadersContentLength) {
 			// We've received all the data
+			SCGIHeadersContentLength = 0
 			let handler = SCGIMessageHandler(message: SCGIMessage(data: requestData!),
 				requestFileHandle: incomingFileHandle, server: self)
 			responseHandlers.append(handler);

--- a/SwiftSCGI/main.swift
+++ b/SwiftSCGI/main.swift
@@ -11,6 +11,6 @@ import Foundation
 let server = SCGIServer(port: 9998)
 server.start()
 
-println("SwiftSCGI listening on port \(server.port)")
+print("SwiftSCGI listening on port \(server.port)")
 
 CFRunLoopRun()


### PR DESCRIPTION
Noticed a bug with the SCGI server. Content length was not being reset, so the server would hang in certain circumstances.

With lighttpd configured for scgi at `/api/`:
If the first route I hit is `/api/asd`
The server would hang at `/api/a`
This occurred consistently if the first route I hit has `n` letters after `/api/` and the next route has `n-2` or fewer letters.

This issue doesn't occur when you go to `/api/` as the first route, although I'm guessing there are other issues with not resetting the content length :)

This PR includes #1, conversion to Swift 2.0
The only difference is the addition of `SCGIHeadersContentLength = 0` at line 171 of `SCGIServer.swift`
